### PR TITLE
Refactor architecture and introduce memory trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,7 +112,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -138,6 +144,21 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -201,6 +222,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +249,31 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "cssparser"
@@ -283,6 +342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +383,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -463,6 +534,11 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -740,6 +816,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +882,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "mac"
@@ -839,6 +942,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -960,8 +1075,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1092,6 +1213,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1383,6 +1524,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,10 +1585,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -1458,6 +1636,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1502,6 +1702,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossterm",
+ "ratatui",
  "regex",
  "reqwest",
  "scraper",
@@ -1574,7 +1776,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -1702,6 +1904,23 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1856,6 +2075,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,11 +2133,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1905,7 +2155,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1914,15 +2179,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1932,9 +2203,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1950,9 +2233,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1962,9 +2257,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.45.1", features = ["full", "macros"] }
 clap = { version = "4.5.2", features = ["derive"] }
+ratatui = "0.26.1"
+crossterm = "0.27.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+use std::io::{self};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, MouseEventKind};
+use crossterm::execute;
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::prelude::*;
+use ratatui::backend::CrosstermBackend;
+use ratatui::widgets::ListState;
+
+use crate::memory::KeywordStore;
+use crate::syosetu::{Chapter, SyosetuClient};
+use crate::ui::{draw_directory, draw_loading, draw_reading};
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum InputMode {
+    Navigate,
+    Search,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum AppState {
+    LoadingDir,
+    Directory,
+    LoadingChapter,
+    Reading,
+}
+
+pub struct App {
+    pub state: AppState,
+    pub mode: InputMode,
+    pub chapters: Vec<Chapter>,
+    pub filtered: Vec<usize>,
+    pub selected: usize,
+    pub search: String,
+    pub content: String,
+    pub translation: String,
+    pub novel_id: String,
+    pub keywords: HashMap<String, String>,
+}
+
+impl App {
+    pub fn new(novel_id: String) -> Self {
+        App {
+            state: AppState::LoadingDir,
+            mode: InputMode::Navigate,
+            chapters: Vec::new(),
+            filtered: Vec::new(),
+            selected: 0,
+            search: String::new(),
+            content: String::new(),
+            translation: String::new(),
+            novel_id,
+            keywords: HashMap::new(),
+        }
+    }
+
+    pub fn apply_filter(&mut self) {
+        if self.search.is_empty() {
+            self.filtered = (0..self.chapters.len()).collect();
+        } else {
+            let q = self.search.to_lowercase();
+            self.filtered = self
+                .chapters
+                .iter()
+                .enumerate()
+                .filter_map(|(i, ch)| {
+                    if ch.title.to_lowercase().contains(&q) || (i + 1).to_string().contains(&q) {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        }
+        if self.selected >= self.filtered.len() {
+            self.selected = 0;
+        }
+    }
+
+    pub async fn run(mut self, url: &str, client: &SyosetuClient, store: &dyn KeywordStore) -> Result<()> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend)?;
+
+        terminal.draw(|f| draw_loading(f, "Loading directory..."))?;
+        let chapters = client.fetch_directory(url).await?;
+        self.chapters = chapters;
+        self.apply_filter();
+        self.state = AppState::Directory;
+
+        self.keywords = store.load(&self.novel_id)?;
+
+        let mut list_state = ListState::default();
+        list_state.select(Some(0));
+
+        let tick_rate = Duration::from_millis(200);
+        let mut last_tick = Instant::now();
+        loop {
+            terminal.draw(|f| match self.state {
+                AppState::LoadingDir => draw_loading(f, "Loading directory..."),
+                AppState::Directory => draw_directory(f, &self, &mut list_state),
+                AppState::LoadingChapter => draw_loading(f, "Loading chapter..."),
+                AppState::Reading => draw_reading(f, &self),
+            })?;
+
+            let timeout = tick_rate
+                .checked_sub(last_tick.elapsed())
+                .unwrap_or_else(|| Duration::from_secs(0));
+
+            if event::poll(timeout)? {
+                match event::read()? {
+                    Event::Key(k) => match self.state {
+                        AppState::Directory => match self.mode {
+                            InputMode::Navigate => match k.code {
+                                KeyCode::Char('j') | KeyCode::Down => {
+                                    if self.selected + 1 < self.filtered.len() {
+                                        self.selected += 1;
+                                        list_state.select(Some(self.selected));
+                                    }
+                                }
+                                KeyCode::Char('k') | KeyCode::Up => {
+                                    if self.selected > 0 {
+                                        self.selected -= 1;
+                                        list_state.select(Some(self.selected));
+                                    }
+                                }
+                                KeyCode::Enter => {
+                                    if let Some(&idx) = self.filtered.get(self.selected) {
+                                        let chapter = &self.chapters[idx];
+                                        self.state = AppState::LoadingChapter;
+                                        terminal.draw(|f| draw_loading(f, "Loading chapter..."))?;
+                                        let content = client.fetch_chapter(&chapter.path).await?;
+                                        self.content = content.clone();
+                                        let existing: Vec<(String, String)> = self
+                                            .keywords
+                                            .iter()
+                                            .map(|(k, v)| (k.clone(), v.clone()))
+                                            .collect();
+                                        let trans = client.translate_text(&content, &existing).await?;
+                                        self.translation = trans.clone();
+                                        let existing_lines: Vec<String> = existing
+                                            .iter()
+                                            .map(|(jp, zh)| {
+                                                format!("{{\"japanese\":\"{}\",\"chinese\":\"{}\"}}", jp, zh)
+                                            })
+                                            .collect();
+                                        let new_keywords = client
+                                            .extract_keywords(&self.translation, &self.content, existing_lines)
+                                            .await?;
+                                        for line in new_keywords {
+                                            if let Ok(val) = serde_json::from_str::<HashMap<String, String>>(&line) {
+                                                if let (Some(jp), Some(zh)) = (val.get("japanese"), val.get("chinese")) {
+                                                    self.keywords.entry(jp.to_string()).or_insert(zh.to_string());
+                                                }
+                                            }
+                                        }
+                                        store.save(&self.novel_id, &self.keywords)?;
+                                        self.state = AppState::Reading;
+                                    }
+                                }
+                                KeyCode::Char('/') => {
+                                    self.mode = InputMode::Search;
+                                    self.search.clear();
+                                }
+                                KeyCode::Char('q') => break,
+                                _ => {}
+                            },
+                            InputMode::Search => match k.code {
+                                KeyCode::Esc => {
+                                    self.mode = InputMode::Navigate;
+                                }
+                                KeyCode::Enter => {
+                                    self.apply_filter();
+                                    list_state.select(Some(self.selected));
+                                    self.mode = InputMode::Navigate;
+                                }
+                                KeyCode::Backspace => {
+                                    self.search.pop();
+                                }
+                                KeyCode::Char(c) => {
+                                    self.search.push(c);
+                                }
+                                _ => {}
+                            },
+                        },
+                        AppState::Reading => match k.code {
+                            KeyCode::Char('q') => break,
+                            KeyCode::Char('b') => {
+                                self.state = AppState::Directory;
+                            }
+                            _ => {}
+                        },
+                        _ => {}
+                    },
+                    Event::Mouse(m) => {
+                        if self.state == AppState::Directory {
+                            if let MouseEventKind::Down(_) = m.kind {
+                                let row = m.row as usize;
+                                if row < self.filtered.len() {
+                                    self.selected = row;
+                                    list_state.select(Some(self.selected));
+                                }
+                            }
+                        }
+                    }
+                    Event::Resize(_, _) => {}
+                    _ => {}
+                }
+            }
+
+            if last_tick.elapsed() >= tick_rate {
+                last_tick = Instant::now();
+            }
+        }
+
+        disable_raw_mode()?;
+        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        terminal.show_cursor()?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,44 +1,14 @@
-use std::sync::Arc;
-
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::Parser;
-use reqwest::Client;
-use scraper::{Html, Selector};
 
-const SYOSETU_API_BASE: &str = "https://ncode.syosetu.com/";
-const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
-AppleWebKit/537.36 (KHTML, like Gecko) \
-Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0";
+use crate::app::App;
+use crate::memory::JsonStore;
+use crate::syosetu::SyosetuClient;
 
-const TRANSLATE_PROMPT: &str = r##"
-请将以下日文内容完整、准确地翻译成中文。  
-要求：  
-1. 保持原文段落结构；  
-2. 不要添加任何解释、注释或额外信息；  
-3. **仅输出译文，不要输出原文或其他解释；**
-4. 注重文章原本的表达，特别是对话需要准确反映语气与人物特点。
-
-{}
-"##;
-
-const KEYWORD_PROMPT: &str = r##"
-请根据以下已提取的翻译列表、日文原文和中文译文，从中找出新的专有名词（日文原文中的人名、地名、招式名、非常见物品名等），以及它们在译文中的对应中文译名。  
-要求：  
-1. 仅输出新的翻译对照，不要重复已提取条目；  
-2. 输出格式为 JSONL，每行一个，例如：{"japanese": "トウリ", "chinese": "托莉"}；  
-3. **不要添加任何说明、注释或其他额外内容。不要使用markdown格式或使用三引号将json包裹**
-
-已提取的翻译列表：  
-{existing_pairs}  
-
-日文原文：  
-{japanese_text}  
-
-中文译文：  
-{chinese_text}
-"##;
-
-const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/chat/completions";
+mod app;
+mod memory;
+mod syosetu;
+mod ui;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "syosetu scraper")]
@@ -56,154 +26,19 @@ struct Args {
     model: String,
 }
 
-struct SyosetuClient {
-    client: Arc<Client>,
-    api_key: String,
-    model: String,
-}
-
-impl SyosetuClient {
-    fn new(api_key: String, model: String) -> Self {
-        SyosetuClient {
-            client: Arc::new(Client::new()),
-            api_key,
-            model,
-        }
-    }
-
-    async fn process_novel(&self, url: &str) -> Result<()> {
-        // 获取目录页面
-        let directory_html = self
-            .client
-            .get(url)
-            .header("User-Agent", USER_AGENT)
-            .send()
-            .await?
-            .text()
-            .await?;
-
-        let document = Html::parse_document(&directory_html);
-        let link_selector = Selector::parse("a.p-eplist__subtitle")
-            .map_err(|e| anyhow!("selector parse error: {e}"))?;
-        // 提取所有章节链接和文本
-        let links: Vec<(String, String)> = document
-            .select(&link_selector)
-            .filter_map(|el| {
-                let href = el.value().attr("href")?;
-                let text = el
-                    .text()
-                    .map(str::trim)
-                    .filter(|t| !t.is_empty())
-                    .collect::<Vec<_>>()
-                    .join("");
-                Some((href.to_string(), text))
-            })
-            .collect();
-
-        if let Some((path, _title)) = links.get(30) {
-            let full_url = format!("{SYOSETU_API_BASE}{}", path);
-            let content_html = self
-                .client
-                .get(&full_url)
-                .header("User-Agent", USER_AGENT)
-                .send()
-                .await?
-                .text()
-                .await?;
-
-            let document = Html::parse_document(&content_html);
-            let body_selector = Selector::parse("div.p-novel__body")
-                .map_err(|e| anyhow!("selector parse error: {e}"))?;
-
-            if let Some(element) = document.select(&body_selector).next() {
-                let content = element
-                    .text()
-                    .map(str::trim)
-                    .filter(|t| !t.is_empty())
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                let trans = self.translate_text(&content).await?;
-                let new_keywords = self.extract_keywords(&trans, &content, Vec::new()).await?;
-                println!("{trans}");
-                for keyword in new_keywords {
-                    println!("{keyword}")
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn translate_text(&self, input: &str) -> Result<String> {
-        let req = serde_json::json!({
-           "model": self.model,
-           "messages": [
-               {"role": "user", "content": TRANSLATE_PROMPT.replace("{}", input)}
-           ],
-           "max_tokens": 8192,
-           "temperature": 1.3,
-           "stream": false,
-        });
-        let resp = self
-            .client
-            .post(DEEPSEEK_API_BASE)
-            .json(&req)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .send()
-            .await?;
-        // println!("{}", resp.text().await.unwrap());
-        // unimplemented!();
-        let output = resp
-            .json::<serde_json::Value>()
-            .await?
-            .pointer("/choices/0/message/content")
-            .ok_or(anyhow!("deepseek api response api error"))?
-            .as_str()
-            .unwrap_or("")
-            .to_string();
-        Ok(output)
-    }
-
-    async fn extract_keywords(
-        &self,
-        zh: &str,
-        jp: &str,
-        keywords: Vec<String>,
-    ) -> Result<Vec<String>> {
-        let req = serde_json::json!({
-           "model": self.model,
-           "messages": [
-               {"role": "user", "content": KEYWORD_PROMPT.replace("{existing_pairs}", &format!("{keywords:?}")).replace("{japanese_text}", jp).replace("{chineses_text}", zh)}
-           ],
-           "max_tokens": 8192,
-           "temperature": 1.3,
-           "stream": false,
-        });
-        let resp = self
-            .client
-            .post(DEEPSEEK_API_BASE)
-            .json(&req)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .send()
-            .await?;
-        // println!("{}", resp.text().await.unwrap());
-        // unimplemented!();
-        let output = resp
-            .json::<serde_json::Value>()
-            .await?
-            .pointer("/choices/0/message/content")
-            .ok_or(anyhow!("deepseek api response api error"))?
-            .as_str()
-            .unwrap_or("")
-            .to_string();
-
-        Ok(output.split('\n').map(|s| s.to_string()).collect())
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+    let novel_id = args
+        .url
+        .trim_end_matches('/')
+        .split('/')
+        .last()
+        .unwrap_or("novel")
+        .to_string();
+
     let client = SyosetuClient::new(args.api_key, args.model);
-    client.process_novel(&args.url).await
+    let store = JsonStore::new("keywords.json");
+    let app = App::new(novel_id);
+    app.run(&args.url, &client, &store).await
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+pub trait KeywordStore: Send + Sync {
+    fn load(&self, novel_id: &str) -> Result<HashMap<String, String>>;
+    fn save(&self, novel_id: &str, keywords: &HashMap<String, String>) -> Result<()>;
+}
+
+pub struct JsonStore {
+    path: PathBuf,
+}
+
+impl JsonStore {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+        JsonStore { path: path.into() }
+    }
+
+    fn read_all(&self) -> HashMap<String, HashMap<String, String>> {
+        if let Ok(content) = fs::read_to_string(&self.path) {
+            serde_json::from_str(&content).unwrap_or_default()
+        } else {
+            HashMap::new()
+        }
+    }
+
+    fn write_all(&self, data: &HashMap<String, HashMap<String, String>>) -> Result<()> {
+        let s = serde_json::to_string_pretty(data)?;
+        fs::write(&self.path, s)?;
+        Ok(())
+    }
+}
+
+impl KeywordStore for JsonStore {
+    fn load(&self, novel_id: &str) -> Result<HashMap<String, String>> {
+        let all = self.read_all();
+        Ok(all.get(novel_id).cloned().unwrap_or_default())
+    }
+
+    fn save(&self, novel_id: &str, keywords: &HashMap<String, String>) -> Result<()> {
+        let mut all = self.read_all();
+        let entry = all.entry(novel_id.to_string()).or_default();
+        for (jp, zh) in keywords {
+            entry.entry(jp.clone()).or_insert(zh.clone());
+        }
+        self.write_all(&all)
+    }
+}

--- a/src/syosetu.rs
+++ b/src/syosetu.rs
@@ -1,0 +1,193 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use reqwest::Client;
+use scraper::{Html, Selector};
+
+pub const SYOSETU_API_BASE: &str = "https://ncode.syosetu.com/";
+const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+AppleWebKit/537.36 (KHTML, like Gecko) \
+Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0";
+
+const TRANSLATE_PROMPT: &str = r##"请将以下日文内容完整、准确地翻译成中文。
+要求：
+1. 保持原文段落结构；
+2. 不要添加任何解释、注释或额外信息；
+3. **仅输出译文，不要输出原文或其他解释；**
+4. 注重文章原本的表达，特别是对话需要准确反映语气与人物特点。
+
+{}"##;
+
+const KEYWORD_PROMPT: &str = r##"请根据以下已提取的翻译列表、日文原文和中文译文，
+从中找出新的专有名词（日文原文中的人名、地名、招式名、非常见物品名等），以及它们
+在译文中的对应中文译名。
+要求：
+1. 仅输出新的翻译对照，不要重复已提取条目；
+2. 输出格式为 JSONL，每行一个，例如:{\"japanese\":\"トウリ\",\"chinese\":\"托莉\"}；
+3. **不要添加任何说明、注释或其他额外内容。不要使用markdown格式或使用三引号将json包裹**
+
+已提取的翻译列表:
+{existing_pairs}
+
+日文原文:
+{japanese_text}
+
+中文译文:
+{chinese_text}"##;
+
+const DEEPSEEK_API_BASE: &str = "https://api.deepseek.com/chat/completions";
+
+#[derive(Clone)]
+pub struct Chapter {
+    pub path: String,
+    pub title: String,
+}
+
+pub struct SyosetuClient {
+    client: Arc<Client>,
+    api_key: String,
+    model: String,
+}
+
+impl SyosetuClient {
+    pub fn new(api_key: String, model: String) -> Self {
+        SyosetuClient {
+            client: Arc::new(Client::new()),
+            api_key,
+            model,
+        }
+    }
+
+    pub async fn fetch_directory(&self, url: &str) -> Result<Vec<Chapter>> {
+        let directory_html = self
+            .client
+            .get(url)
+            .header("User-Agent", USER_AGENT)
+            .send()
+            .await?
+            .text()
+            .await?;
+        let document = Html::parse_document(&directory_html);
+        let link_selector = Selector::parse("a.p-eplist__subtitle")
+            .map_err(|e| anyhow!("selector parse error: {e}"))?;
+        let links: Vec<Chapter> = document
+            .select(&link_selector)
+            .filter_map(|el| {
+                let href = el.value().attr("href")?;
+                let text = el
+                    .text()
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .collect::<Vec<_>>()
+                    .join("");
+                Some(Chapter {
+                    path: href.to_string(),
+                    title: text,
+                })
+            })
+            .collect();
+        Ok(links)
+    }
+
+    pub async fn fetch_chapter(&self, path: &str) -> Result<String> {
+        let full_url = format!("{SYOSETU_API_BASE}{path}");
+        let content_html = self
+            .client
+            .get(&full_url)
+            .header("User-Agent", USER_AGENT)
+            .send()
+            .await?
+            .text()
+            .await?;
+        let document = Html::parse_document(&content_html);
+        let body_selector = Selector::parse("div.p-novel__body")
+            .map_err(|e| anyhow!("selector parse error: {e}"))?;
+        if let Some(element) = document.select(&body_selector).next() {
+            let content = element
+                .text()
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            Ok(content)
+        } else {
+            Err(anyhow!("body not found"))
+        }
+    }
+
+    pub async fn translate_text(
+        &self,
+        input: &str,
+        keywords: &[(String, String)],
+    ) -> Result<String> {
+        let known = if keywords.is_empty() {
+            String::new()
+        } else {
+            let pairs = keywords
+                .iter()
+                .map(|(jp, zh)| format!("{jp}:{zh}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("已知翻译对照：{pairs}\n")
+        };
+        let content = format!("{known}{input}");
+        let req = serde_json::json!({
+           "model": self.model,
+           "messages": [
+               {"role": "user", "content": TRANSLATE_PROMPT.replace("{}", &content)}
+           ],
+           "max_tokens": 8192,
+           "temperature": 1.3,
+           "stream": false,
+        });
+        let resp = self
+            .client
+            .post(DEEPSEEK_API_BASE)
+            .json(&req)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await?;
+        let output = resp
+            .json::<serde_json::Value>()
+            .await?
+            .pointer("/choices/0/message/content")
+            .ok_or(anyhow!("deepseek api response api error"))?
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        Ok(output)
+    }
+
+    pub async fn extract_keywords(
+        &self,
+        zh: &str,
+        jp: &str,
+        keywords: Vec<String>,
+    ) -> Result<Vec<String>> {
+        let req = serde_json::json!({
+           "model": self.model,
+           "messages": [
+               {"role": "user", "content": KEYWORD_PROMPT.replace("{existing_pairs}", &format!("{keywords:?}")).replace("{japanese_text}", jp).replace("{chinese_text}", zh)}
+           ],
+           "max_tokens": 8192,
+           "temperature": 1.3,
+           "stream": false,
+        });
+        let resp = self
+            .client
+            .post(DEEPSEEK_API_BASE)
+            .json(&req)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await?;
+        let output = resp
+            .json::<serde_json::Value>()
+            .await?
+            .pointer("/choices/0/message/content")
+            .ok_or(anyhow!("deepseek api response api error"))?
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        Ok(output.split('\n').map(|s| s.to_string()).collect())
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,42 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+use crate::app::{App, InputMode};
+
+pub fn draw_loading(frame: &mut Frame, message: &str) {
+    let area = frame.size();
+    let block = Block::default().title(message).borders(Borders::ALL);
+    frame.render_widget(block, area);
+}
+
+pub fn draw_directory(frame: &mut Frame, app: &App, state: &mut ListState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(3)])
+        .split(frame.size());
+
+    let items: Vec<ListItem> = app
+        .filtered
+        .iter()
+        .map(|&i| ListItem::new(app.chapters[i].title.clone()))
+        .collect();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title("Chapters"))
+        .highlight_symbol(">>");
+    frame.render_stateful_widget(list, chunks[0], state);
+
+    let search = Paragraph::new(app.search.as_str()).block(
+        Block::default().borders(Borders::ALL).title(match app.mode {
+            InputMode::Navigate => "Press '/' to search",
+            InputMode::Search => "Search",
+        }),
+    );
+    frame.render_widget(search, chunks[1]);
+}
+
+pub fn draw_reading(frame: &mut Frame, app: &App) {
+    let area = frame.size();
+    let para = Paragraph::new(app.translation.as_str())
+        .block(Block::default().borders(Borders::ALL).title("Translation"));
+    frame.render_widget(para, area);
+}


### PR DESCRIPTION
## Summary
- split logic into separate modules for clarity
- add `KeywordStore` trait with `JsonStore` implementation
- restructure main to use the new modules
- move Syosetu client and UI drawing into their own files

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684dbf4fbf8483269c34fb84ee278762