### PR TITLE
Add syosetu.org support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1712,7 @@ name = "syosetu-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "crossterm",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1.45.1", features = ["full", "macros"] }
 clap = { version = "4.5.2", features = ["derive"] }
 ratatui = "0.26.1"
 crossterm = "0.27.0"
+async-trait = "0.1.77"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 use crate::app::App;
 use crate::memory::{JsonStore, JsonTranslationStore};
-use crate::syosetu::SyosetuClient;
+use crate::syosetu::{NcodeSite, OrgSite, NovelSite, Translator};
 
 mod app;
 mod memory;
@@ -39,9 +39,14 @@ async fn main() -> Result<()> {
         .unwrap_or("novel")
         .to_string();
 
-    let client = SyosetuClient::new(args.api_key, args.model);
+    let translator = Translator::new(args.api_key, args.model);
+    let site: Box<dyn NovelSite> = if args.url.contains("syosetu.org") {
+        Box::new(OrgSite::new())
+    } else {
+        Box::new(NcodeSite::new())
+    };
     let store = JsonStore::new("keywords.json");
     let trans_store = JsonTranslationStore::new("translations.json");
     let app = App::new(novel_id);
-    app.run(&args.url, &client, &store, &trans_store).await
+    app.run(&args.url, site.as_ref(), &translator, &store, &trans_store).await
 }


### PR DESCRIPTION
## Summary
- abstract website interaction via `NovelSite` trait
- add `Translator` struct for DeepSeek translation
- implement `NcodeSite` and `OrgSite` for ncode.syosetu.com and syosetu.org
- detect URL on startup and select the appropriate site implementation

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684dd34b8e5083269f4172ed70ce29f1