### PR TITLE
Add logging for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +874,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1217,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1715,6 +1777,8 @@ dependencies = [
  "async-trait",
  "clap",
  "crossterm",
+ "env_logger",
+ "log",
  "ratatui",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ clap = { version = "4.5.2", features = ["derive"] }
 ratatui = "0.26.1"
 crossterm = "0.27.0"
 async-trait = "0.1.77"
+log = "0.4"
+env_logger = "0.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
+use log::error;
 
 use crate::app::App;
 use crate::memory::{JsonStore, JsonTranslationStore};
@@ -30,6 +31,7 @@ struct Args {
 /// 解析参数并启动应用
 #[tokio::main]
 async fn main() -> Result<()> {
+    env_logger::init();
     let args = Args::parse();
     let novel_id = args
         .url
@@ -48,5 +50,11 @@ async fn main() -> Result<()> {
     let store = JsonStore::new("keywords.json");
     let trans_store = JsonTranslationStore::new("translations.json");
     let app = App::new(novel_id);
-    app.run(&args.url, site.as_ref(), &translator, &store, &trans_store).await
+    let result = app
+        .run(&args.url, site.as_ref(), &translator, &store, &trans_store)
+        .await;
+    if let Err(ref e) = result {
+        error!("Application error: {:?}", e);
+    }
+    result
 }


### PR DESCRIPTION
## Summary
- add `log` and `env_logger` dependencies
- initialize logger and print errors on failure

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e377c53dc8326bcf4fd4fff76dd4d