### PR TITLE
Adjust log level to info

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use log::error;
+use log::{error, LevelFilter};
 use std::fs::OpenOptions;
 use env_logger::{Builder, Target};
 
@@ -38,6 +38,7 @@ async fn main() -> Result<()> {
         .append(true)
         .open("app.log")?;
     Builder::from_default_env()
+        .filter_level(LevelFilter::Info)
         .target(Target::Pipe(Box::new(log_file)))
         .init();
     let args = Args::parse();


### PR DESCRIPTION
## Summary
- set env_logger filter level to `info`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e414ad2608326ab817220e1b9be49