### PR TITLE
Enable redirect handling

### DIFF
--- a/src/syosetu.rs
+++ b/src/syosetu.rs
@@ -157,8 +157,12 @@ pub struct NcodeSite {
 
 impl NcodeSite {
     pub fn new() -> Self {
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .build()
+            .expect("failed to build reqwest client");
         NcodeSite {
-            client: Arc::new(Client::new()),
+            client: Arc::new(client),
         }
     }
 }
@@ -231,8 +235,12 @@ pub struct OrgSite {
 
 impl OrgSite {
     pub fn new() -> Self {
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .build()
+            .expect("failed to build reqwest client");
         OrgSite {
-            client: Arc::new(Client::new()),
+            client: Arc::new(client),
         }
     }
 }


### PR DESCRIPTION
## Summary
- follow 302 redirects by default when fetching directory or chapter

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684ea29b64208326a4d30cf59288a522