### PR TITLE
Implement async chapter processing

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -47,10 +47,12 @@ impl JsonTranslationStore {
         }
     }
 
-    /// 将内存中的数据写回文件
+    /// 将内存中的数据写回文件，先写入临时文件再原子覆盖，避免意外写入
     fn write_all(&self, data: &HashMap<String, HashMap<String, String>>) -> Result<()> {
         let s = serde_json::to_string_pretty(data)?;
-        fs::write(&self.path, s)?;
+        let tmp_path = self.path.with_extension("tmp");
+        fs::write(&tmp_path, s)?;
+        fs::rename(&tmp_path, &self.path)?;
         Ok(())
     }
 }
@@ -73,7 +75,9 @@ impl JsonStore {
     /// 写回全部数据
     fn write_all(&self, data: &HashMap<String, HashMap<String, String>>) -> Result<()> {
         let s = serde_json::to_string_pretty(data)?;
-        fs::write(&self.path, s)?;
+        let tmp_path = self.path.with_extension("tmp");
+        fs::write(&tmp_path, s)?;
+        fs::rename(&tmp_path, &self.path)?;
         Ok(())
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,6 +24,8 @@ pub fn draw_directory(frame: &mut Frame, app: &App, state: &mut ListState) {
             let ch = &app.chapters[i];
             let mark = if app.cached_chapters.contains(&ch.path) {
                 "[C] "
+            } else if app.processing_chapters.contains(&ch.path) {
+                "[P] "
             } else {
                 "[ ] "
             };


### PR DESCRIPTION
## Summary
- support asynchronous translation of uncached chapters
- show `[P]` indicator for chapters being processed
- avoid corrupted files by writing through temporary files

## Testing
- `cargo test`
- `cargo clippy --all-targets -- -D warnings` *(fails: `cargo-clippy` not installed)*
- `cargo fmt` *(fails: `cargo-fmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684eef0fa28c832693fb2cdcd0e4a004