### PR TITLE
Implement async chapter processing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -225,22 +225,25 @@ impl App {
                                     if let Some(&idx) = self.filtered.get(self.selected) {
                                         let chapter = &self.chapters[idx];
                                         self.scroll = 0;
-                                        self.current_chapter = Some(chapter.path.clone());
-                                        if let Some(trans) = trans_store.load(&self.novel_id, &chapter.path)? {
+                                        if let Some(trans) =
+                                            trans_store.load(&self.novel_id, &chapter.path)?
+                                        {
+                                            self.current_chapter = Some(chapter.path.clone());
                                             self.translation = trans;
                                             self.state = AppState::Reading;
-                                        } else {
-                                            if !self.processing.contains_key(&chapter.path) {
-                                                self.spawn_processing(
-                                                    chapter.clone(),
-                                                    site.clone(),
-                                                    translator.clone(),
-                                                    kw_store.clone(),
-                                                    trans_store.clone(),
-                                                );
-                                            }
+                                        } else if self.processing.contains_key(&chapter.path) {
+                                            self.current_chapter = Some(chapter.path.clone());
                                             self.translation = "Processing...".to_string();
                                             self.state = AppState::Reading;
+                                        } else {
+                                            self.spawn_processing(
+                                                chapter.clone(),
+                                                site.clone(),
+                                                translator.clone(),
+                                                kw_store.clone(),
+                                                trans_store.clone(),
+                                            );
+                                            // stay in directory so user can queue more tasks
                                         }
                                     }
                                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,6 +24,8 @@ pub fn draw_directory(frame: &mut Frame, app: &App, state: &mut ListState) {
             let ch = &app.chapters[i];
             let mark = if app.cached_chapters.contains(&ch.path) {
                 "[C] "
+            } else if app.processing.contains_key(&ch.path) {
+                "[P] "
             } else {
                 "[ ] "
             };


### PR DESCRIPTION
## Summary
- enable background processing of uncached chapters
- mark processing chapters in the directory
- atomically write translation files
- adjust storage access with mutexes
- refactor main app to use `Arc` for async tasks
- prevent duplicate processing and merge keyword updates using a shared `Mutex`

## Testing
- `cargo fmt` *(fails: `cargo-fmt` is not installed)*
- `cargo clippy --all-targets -- -D warnings` *(fails: `cargo-clippy` is not installed)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ef6727014832691baf1474eeb1156